### PR TITLE
Enable pod_spelling_system test back

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -38,5 +38,3 @@ contributor = Steffen Müller
 
 [PruneFiles]
 filename = xt/release/changes.t
-; some unicode issue needs to be resolved:
-filename = xt/author/pod_spelling_system.t


### PR DESCRIPTION
I was able to trace the issue back to Test::Spelling, and
submitted PR https://github.com/sartak/test-spelling/pull/10

This commit obviously depend on that PR to be merged and
released. Afterwards, we might want to specify newest
version of Test::Spelling as required in dist.ini too.