### PR TITLE
Add provides to META.yml

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -36,6 +36,8 @@ original = Adam Kennedy <adamk@cpan.org>
 contributor = Tom Wyant
 contributor = Steffen Müller
 
+[MetaProvides::Package]
+
 [PruneFiles]
 filename = xt/release/changes.t
 ; some unicode issue needs to be resolved:


### PR DESCRIPTION
Adding [MetaProvides::Package] adds two modules to META.yml:
Class::Inspector and Class::Inspector::Functions.
This was the only item in CPANTS for kwalitee score.