### PR TITLE
reorg tests

### DIFF
--- a/t/01_use.t
+++ b/t/01_use.t
@@ -1,11 +1,8 @@
-#!/usr/bin/perl
-
-# Compile testing for Class::Inspector
-
 use strict;
 use warnings;
-use Test::More tests => 2;
+use Test::More tests => 3;
 
 ok( $] >= 5.006, "Your perl is new enough" );
 
 use_ok('Class::Inspector');
+use_ok('Class::Inspector::Functions');

--- a/t/class_inspector.t
+++ b/t/class_inspector.t
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 # Unit testing for Class::Inspector
 
 # Do all the tests on ourself, where possible, as we know we will be loaded.

--- a/t/class_inspector__inc_to_local.t
+++ b/t/class_inspector__inc_to_local.t
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 # Unit testing for Class::Inspector
 
 # Do all the tests on ourself, where possible, as we know we will be loaded.

--- a/t/class_inspector_functions.t
+++ b/t/class_inspector_functions.t
@@ -1,5 +1,3 @@
-#!/usr/bin/perl
-
 # Reproduce some of the unit tests in the main unit tests
 # of the method interface, but not all. This makes the maintenance
 # slightly less annoying.


### PR DESCRIPTION
use names for tests based on the classes to which they belong
